### PR TITLE
DEVX-6440: Updating whatsapp template snippets

### DIFF
--- a/DotNetCliCodeSnippets/Messages/WhatsApp/SendWhatsAppMtm.cs
+++ b/DotNetCliCodeSnippets/Messages/WhatsApp/SendWhatsAppMtm.cs
@@ -35,17 +35,11 @@ public class SendWhatsAppMtm : ICodeSnippet
             Template = new MessageTemplate
             {
                 Name = "whatsapp:hsm:technology:nexmo:mytemplate",
-                Parameters =  new List<object>
+                Parameters =  new List<string>
                 {
-                    new {
-                        @default = "Vonage Verification"
-                    },
-                    new {
-                        @default = "64873"
-                    },
-                    new {
-                        @default = "10"
-                    }
+                    "Vonage Verification"
+                    "64873",
+                    "10"
                 }
             }
         };


### PR DESCRIPTION
Small change to the snippets for sending WhatsApp Template messages. The value for the `parameters` field was incorrect due to an error in the spec.