### PR TITLE
Update Vonage SDK to 8.33.0

### DIFF
--- a/DotNetCliCodeSnippets/DotnetCliCodeSnippets.csproj
+++ b/DotNetCliCodeSnippets/DotnetCliCodeSnippets.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Vonage" Version="8.32.0" />
+    <PackageReference Include="Vonage" Version="8.33.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DotNetWebhookCodeSnippets/DotnetWebhookCodeSnippets.csproj
+++ b/DotNetWebhookCodeSnippets/DotnetWebhookCodeSnippets.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
-    <PackageReference Include="Vonage" Version="8.32.0" />
+    <PackageReference Include="Vonage" Version="8.33.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates the Vonage .NET SDK to version 8.33.0.